### PR TITLE
Informal sal update

### DIFF
--- a/district_data_import.py
+++ b/district_data_import.py
@@ -144,6 +144,15 @@ for stu_number, district_record in district_records.iteritems():
             'ZIP': district_record['zip']
         })
 
+        # Update for potential switch of parent name order
+        dp_donorrecord_with_pnames = district_data_utils.create_dp_donorrecord(district_record=district_record, school_year=args.school_year)
+        dp_donorrecord.update({
+            'FIRST_NAME': dp_donorrecord_with_pnames['FIRST_NAME'],
+            'LAST_NAME': dp_donorrecord_with_pnames['LAST_NAME'],
+            'SP_FNAME': dp_donorrecord_with_pnames['SP_FNAME'],
+            'SP_LNAME': dp_donorrecord_with_pnames['SP_LNAME'],
+        })
+
         # Update email based on parent1 email
         if district_record['Parent1Email'] and not dp_donorrecord['EMAIL']:
             dp_donorrecord['EMAIL'] = district_record['Parent1Email']

--- a/district_data_import.py
+++ b/district_data_import.py
@@ -151,6 +151,10 @@ for stu_number, district_record in district_records.iteritems():
             'LAST_NAME': dp_donorrecord_with_pnames['LAST_NAME'],
             'SP_FNAME': dp_donorrecord_with_pnames['SP_FNAME'],
             'SP_LNAME': dp_donorrecord_with_pnames['SP_LNAME'],
+            'EMAIL': dp_donorrecord_with_pnames['EMAIL'],
+            'SPOUSE_EMAIL': dp_donorrecord_with_pnames['SPOUSE_EMAIL'],
+            'MOBILE_PHONE': dp_donorrecord_with_pnames['MOBILE_PHONE'],
+            'SPOUSE_MOBILE': dp_donorrecord_with_pnames['SPOUSE_MOBILE']
         })
 
         # Update email based on parent1 email

--- a/district_data_import.py
+++ b/district_data_import.py
@@ -160,7 +160,6 @@ for stu_number, district_record in district_records.iteritems():
             'SPOUSE_EMAIL': dp_donorrecord_for_update['SPOUSE_EMAIL'],
             'MOBILE_PHONE': dp_donorrecord_for_update['MOBILE_PHONE'],
             'SPOUSE_MOBILE': dp_donorrecord_for_update['SPOUSE_MOBILE'],
-            'SALUTATION': dp_donorrecord_for_update['SALUTATION'],
             'OPT_LINE': dp_donorrecord_for_update['OPT_LINE']
         })
 
@@ -171,7 +170,10 @@ for stu_number, district_record in district_records.iteritems():
         potential_auto_informal_sal = district_data_utils.create_informal_sal(dp_donorrecord['SP_FNAME'], dp_donorrecord['FIRST_NAME'])
         new_informal_sal = district_data_utils.create_informal_sal(dp_donorrecord['FIRST_NAME'], dp_donorrecord['SP_FNAME'])
         if curr_informal_sal == potential_auto_informal_sal: # Informal salutation has not been personalized
-            dp_donorrecord.update({ 'INFORMAL_SAL': new_informal_sal })
+            dp_donorrecord.update({ 
+                'SALUTATION': dp_donorrecord_for_update['SALUTATION'],
+                'INFORMAL_SAL': new_informal_sal 
+            })
 
         # Update email based on parent1 email
         if district_record['Parent1Email'] and not dp_donorrecord['EMAIL']:

--- a/district_data_import.py
+++ b/district_data_import.py
@@ -12,8 +12,8 @@ FILENAME_NEWSTUDENT = '02-new-students.csv'
 FILENAME_NEWDONOR = '03-new-donors.csv'
 FILENAME_DONOR_UPDATES = '04-donor-updates.csv'
 FILENAME_DONOR_UPDATE_MESSAGES = '05-donor-manual-updates.txt'
-FILENAME_INFORMAL_SAL_UPDATES = '06-informal-sal-updates.csv'
-FILENAME_INFORMAL_SAL_PERSONALIZED = '07-informal-sal-personalized.csv'
+FILENAME_INFORMAL_SAL_UPDATES = 'REF-informal-sal-updates.csv'
+FILENAME_INFORMAL_SAL_PERSONALIZED = 'REF-informal-sal-personalized.csv'
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dp-report",
@@ -161,7 +161,9 @@ for stu_number, district_record in district_records.iteritems():
             'EMAIL': dp_donorrecord_with_pnames['EMAIL'],
             'SPOUSE_EMAIL': dp_donorrecord_with_pnames['SPOUSE_EMAIL'],
             'MOBILE_PHONE': dp_donorrecord_with_pnames['MOBILE_PHONE'],
-            'SPOUSE_MOBILE': dp_donorrecord_with_pnames['SPOUSE_MOBILE']
+            'SPOUSE_MOBILE': dp_donorrecord_with_pnames['SPOUSE_MOBILE'],
+            'SALUTATION': dp_donorrecord_with_pnames['SALUTATION'],
+            'OPT_LINE': dp_donorrecord_with_pnames['OPT_LINE']
         })
 
         # For informal salutations, we update it only if it is a straightforward switch of the parent name order. 
@@ -177,21 +179,19 @@ for stu_number, district_record in district_records.iteritems():
 
         row = utils.dict_filtered_copy(dp_donorrecord, informal_sal_headers)
         row['_CURR_INFORMAL_SAL'] = curr_informal_sal
-        if curr_main_f_name != dp_donorrecord['FIRST_NAME']: # The district data has caused a name switch
-            expected_informal_sal = create_informal_sal(dp_donorrecord['SP_FNAME'], dp_donorrecord['FIRST_NAME'])
-            new_informal_sal = create_informal_sal(dp_donorrecord['FIRST_NAME'], dp_donorrecord['SP_FNAME'])
-            row['INFORMAL_SAL'] = new_informal_sal
-            if curr_informal_sal == expected_informal_sal: # Informal salutation has not been personalized
-                # Uncomment this line if we want to include this change in the 04-file
-                # dp_donorrecord.update({ 'INFORMAL_SAL': new_informal_sal })
-                row['_ACTION'] = "Update"
-                dp_informal_sal_updates.append(row)
-                #mesg = "Update -- INFORMAL_SAL, " + curr_informal_sal + ", " + new_informal_sal
-            else:
-                row['_ACTION'] = "Leave-as-is"
-                dp_informal_sal_personalized.append(row)
-                #mesg = "No update -- personalized INFORMAL_SAL, " + curr_informal_sal + ", " + new_informal_sal
-            #print (mesg)
+        # Cannot use the conditional below as import may have already occured. 
+        #if curr_main_f_name != dp_donorrecord['FIRST_NAME']: # The district data has caused a name switch
+        potential_auto_informal_sal = create_informal_sal(dp_donorrecord['SP_FNAME'], dp_donorrecord['FIRST_NAME'])
+        new_informal_sal = create_informal_sal(dp_donorrecord['FIRST_NAME'], dp_donorrecord['SP_FNAME'])
+        row['INFORMAL_SAL'] = new_informal_sal
+        if curr_informal_sal == potential_auto_informal_sal: # Informal salutation has not been personalized
+            # Comment this line if we DO NOT want to include informal_sal update in the 04-file
+            dp_donorrecord.update({ 'INFORMAL_SAL': new_informal_sal })
+            row['_ACTION'] = "Update"
+            dp_informal_sal_updates.append(row)
+        else:
+            row['_ACTION'] = "Leave-as-is"
+            dp_informal_sal_personalized.append(row)
 
         # Update email based on parent1 email
         if district_record['Parent1Email'] and not dp_donorrecord['EMAIL']:

--- a/district_data_utils.py
+++ b/district_data_utils.py
@@ -28,7 +28,7 @@ def district_school_to_dp_school(name):
 
 def dp_grade_for_district_record(district_record):
     # District data uses grade 0 for both TK and Kindergarten
-    if district_record['entrycode'] == 'TK':
+    if district_record['entrycode'] == 'TK' or district_record['Grade'] == 'TK':
         return "-1"
     else:
         return district_record['Grade']

--- a/district_data_utils.py
+++ b/district_data_utils.py
@@ -28,11 +28,7 @@ def district_school_to_dp_school(name):
 
 def dp_grade_for_district_record(district_record):
     # District data uses grade 0 for both TK and Kindergarten
-    if district_record['entrycode'] == 'TK' or district_record['Grade'] == 'TK':
-        return "-1"
-    else:
-        return district_record['Grade']
-
+    return "-1" if district_record['Grade'] == 'TK' or district_record['entrycode'] == 'TK' else district_record['Grade']
 
 def create_dp_studentrecord(district_record):
     """Create a DP studentrecord from the given district record"""
@@ -46,6 +42,13 @@ def create_dp_studentrecord(district_record):
     }
     return dp_studentrecord
 
+
+def create_informal_sal(main_f_name, spouse_f_name):
+    if len(spouse_f_name) != 0:
+        informal_sal = main_f_name + " and " + spouse_f_name
+    else:
+        informal_sal = main_f_name
+    return informal_sal
 
 def create_dp_donorrecord(district_record, school_year):
     """Create a DP donorrecord from the given district record (without creating any studentrecords)."""


### PR DESCRIPTION
This generates two new files, 06 and 07. 
* 06 can be eyeballed, and uploaded if desired, it will make the name order consistent with the informal salutation *only if* there are no personalizations to the informal salutation. 
* 07 contains all the records for which there has been a name-switch for which the informal salutation can be manually changed if desired. 