### PR TITLE
Fix bug with DP where setting home-school to NULL instead of spaces.

### DIFF
--- a/district_data_import.py
+++ b/district_data_import.py
@@ -231,7 +231,7 @@ for stu_number, district_record in district_records.iteritems():
 
         #set former_elementary_school if not set already
         if not dp_donorrecord['FORMER_ELEM_SCHOOL'] and dp_donorrecord['HOME_SCHOOL'] == 'BIS':
-            dp_donorrecord['FORMER_ELEM_SCHOOL'] = '' if old_homeschool == 'BIS' else old_homeschool
+            dp_donorrecord['FORMER_ELEM_SCHOOL'] = '' if old_homeschool in ('BIS','NULL') else old_homeschool
 
     else:
         # For multi-donor students, typically both Parent1 and Parent2 are separate donors, and the "spouse" is either


### PR DESCRIPTION
There was a bug in the data from DP where they were sending us "NULL" for home_school field.  I've never seen this before where an empty field gets set to "NULL" instead of "".  Anyway, in DP it's shown as "" (empty field) so it's a bug in their export process.  Instead of waiting for Dp to fix this, I've put a fix in our code to handle if the HOME_SCHOOL is empty or NULL.  This only impacts the setting of FORMER_ELEM_SCHOOL as we set it to the HOME_SCHOOL field that we've downloaded from DP (in this case "NULL").  So I've changed the code to set it to "" if it's set to "NULL".